### PR TITLE
Add simple d3 example

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "eslint": "^3.3.1",
     "eslint-plugin-react": "^6.1.2",
     "expect": "^1.20.2",
+    "extract-text-webpack-plugin": "^1.0.1",
     "html-webpack-plugin": "^2.22.0",
     "mocha": "^3.0.2",
     "postcss-loader": "^0.10.1",

--- a/src/main.css
+++ b/src/main.css
@@ -1,3 +1,11 @@
 .main {
   color: pink
 }
+
+.bar {
+  display: inline-block;
+  width: 20px;
+  height: 75px; /* Gets overriden by D3-assigned height below */
+  margin-right: 2px;
+  background-color: turquoise;
+}

--- a/src/main.js
+++ b/src/main.js
@@ -1,7 +1,7 @@
 import React, { Component } from 'react'
 import { render } from 'react-dom'
 import * as d3 from 'd3'
-import styles from './main.css'
+import './main.css'
 
 require('es6-promise').polyfill();
 require('isomorphic-fetch');
@@ -24,10 +24,19 @@ class App extends Component {
   }
 
   render () {
-    return <div className={styles.main}>Hello, world!</div>
+    return <div>React and D3!</div>
   }
 }
 
-d3.select('body').append('p').text('New paragraph!')
+
+const dataSet = [1, 2, 3, 4, 5, 6]
+
+d3.select('body')
+  .selectAll('div')
+  .data(dataSet)
+  .enter()
+  .append('div')
+  .attr('class', 'bar')
+  .style('height', d => d * 5 + 'px')
 
 render(<App />, document.getElementById('root'))

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -6,13 +6,13 @@ module.exports = {
   entry: __dirname + '/src/main.js',
   output: {
     path: __dirname + '/dist',
-    filename: 'bundle.js'
+    filename: '[name]-[hash].js'
   },
 
   module: {
     loaders: [
       { test: /\.js$/, exclude: /node_modules/, loader: 'babel' },
-      { test: /\.css$/, loader: 'style!css?modules!postcss' }
+      { test: /\.css$/, loader: 'style!css!postcss' }
     ]
   },
 


### PR DESCRIPTION
This commit adds a simple d3 example to the project. I made minor
updates so that the styles would render properly, so CSS modules was
stripped out for the moment. I also added the Extract Text Plugin, which
we will need at some point but now now. To learn how to do what I did with the d3
data visit:
https://egghead.io/lessons/d3-get-started-with-d3?course=introduction-to-d3