### PR TITLE
Add react router and redux

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,14 +1,18 @@
 {
-  "presets": ["react", "es2015"],
+  "presets": ["react", "es2015", "stage-0"],
   "env": {
     "development": {
-    "plugins": [["react-transform", {
+    "plugins": [
+      ["react-transform", {
        "transforms": [{
          "transform": "react-transform-hmr",
          "imports": ["react"],
          "locals": ["module"]
        }]
-     }]]
-    }
+     }],
+      ["babel-root-import", {
+        "rootPathSuffix": "src/common"
+      }]
+    ]}
   }
 }

--- a/.eslintrc
+++ b/.eslintrc
@@ -170,7 +170,7 @@
     "semi": [0],
     "semi-spacing": [2, {"before": false, "after": true}],
     "sort-vars": [0],
-    "space-before-function-paren": [2, {"anonymous": "always", "named": "always"}],
+    "space-before-function-paren": [2, {"anonymous": "always", "named": "never"}],
     "space-before-blocks": [0, "always"],
     "space-in-brackets": [
       0, "never", {

--- a/.eslintrc
+++ b/.eslintrc
@@ -9,7 +9,8 @@
   },
 
   "plugins": [
-    "react"
+    "react",
+    "import"
   ],
 
   "ecmaFeatures": {
@@ -60,6 +61,7 @@
     "generator-star-spacing": [2, "after"],
     "guard-for-in": [0],
     "handle-callback-err": [0],
+    "import/no-unresolved": [2, { "ignore": ["^[~]"] }],
     "key-spacing": [2, {"beforeColon": false, "afterColon": true}],
     "keyword-spacing": [2],
     "quotes": [2, "single", {"avoidEscape": true, "allowTemplateLiterals": true}],

--- a/package.json
+++ b/package.json
@@ -12,7 +12,9 @@
     "isomorphic-fetch": "^2.2.1",
     "react": "^15.3.1",
     "react-dom": "^15.3.1",
-    "react-faux-dom": "^2.7.1"
+    "react-faux-dom": "^2.7.1",
+    "react-router": "^2.8.0",
+    "redux": "^3.6.0"
   },
   "devDependencies": {
     "autoprefixer": "^6.4.0",

--- a/package.json
+++ b/package.json
@@ -11,11 +11,14 @@
     "d3": "^4.2.2",
     "es6-promise": "^3.2.1",
     "isomorphic-fetch": "^2.2.1",
+    "ramda": "^0.22.1",
     "react": "^15.3.1",
     "react-dom": "^15.3.1",
     "react-faux-dom": "^2.7.1",
+    "react-redux": "^4.4.5",
     "react-router": "^2.8.0",
     "redux": "^3.6.0",
+    "redux-thunk": "^2.1.0",
     "reselect": "^2.5.3"
   },
   "devDependencies": {
@@ -31,6 +34,7 @@
     "babel-preset-stage-0": "^6.5.0",
     "css-loader": "^0.23.1",
     "eslint": "^3.3.1",
+    "eslint-plugin-import": "^1.14.0",
     "eslint-plugin-react": "^6.1.2",
     "expect": "^1.20.2",
     "extract-text-webpack-plugin": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "react-dom": "^15.3.1",
     "react-faux-dom": "^2.7.1",
     "react-router": "^2.8.0",
-    "redux": "^3.6.0"
+    "redux": "^3.6.0",
+    "reselect": "^2.5.3"
   },
   "devDependencies": {
     "autoprefixer": "^6.4.0",

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "babel": "^6.5.2",
     "babel-polyfill": "^6.13.0",
     "babel-register": "^6.11.6",
+    "babel-root-import": "^4.1.1",
     "d3": "^4.2.2",
     "es6-promise": "^3.2.1",
     "isomorphic-fetch": "^2.2.1",

--- a/src/common/components/BarChart.js
+++ b/src/common/components/BarChart.js
@@ -1,0 +1,30 @@
+import React, { Component } from 'react'
+import { connect } from 'react-redux'
+
+import { fetchDataIfNeeded } from '~/store/actions'
+import * as selectors from '~/store/selectors'
+
+const mapStateToProps = state => {
+  return {
+    data: selectors.getBarChartData(state)
+  }
+}
+
+class BarChart extends Component {
+
+  static defaultProps = {
+    data: {}
+  }
+
+  componentDidMount() {
+    const { dispatch } = this.props
+    dispatch(fetchDataIfNeeded('bar-chart', 'GDP-data'))
+  }
+
+  render() {
+    const { data } = this.props
+    return <div>Bar Chart Component</div>
+  }
+}
+
+export default connect(mapStateToProps)(BarChart)

--- a/src/common/containers/App.js
+++ b/src/common/containers/App.js
@@ -1,0 +1,15 @@
+import React, { Component } from 'react'
+import { Link } from 'react-router'
+
+export default class App extends Component {
+
+  render() {
+    return (
+      <div>
+        <ul>
+          <li><Link to='/bar-chart'>Bar Chart</Link></li>
+        </ul>
+      </div>
+    )
+  }
+}

--- a/src/common/containers/Root.js
+++ b/src/common/containers/Root.js
@@ -1,0 +1,22 @@
+import React, { Component } from 'react'
+import { Provider } from 'react-redux'
+import { Router, Route } from 'react-router'
+
+import App from './App'
+import BarChart from '~/components/BarChart'
+
+export default class Root extends Component {
+  render() {
+    const { store, history } = this.props
+    return (
+      <Provider store={store}>
+        <div>
+          <Router history={history}>
+            <Route path='/' component={App} />
+            <Route path='/bar-chart' component={BarChart} />
+          </Router>
+        </div>
+      </Provider>
+    )
+  }
+}

--- a/src/common/routes.js
+++ b/src/common/routes.js
@@ -1,0 +1,11 @@
+import React from 'react'
+import { Route } from 'react-router'
+
+import App from './containers/App'
+import BarChart from './components/BarChart'
+
+export default (
+  <Route path="/" component={App}>
+    <Route path="/bar-chart" component={BarChart} />
+  </Route>
+)

--- a/src/common/store/actions/index.js
+++ b/src/common/store/actions/index.js
@@ -1,0 +1,45 @@
+export const REQUEST_DATA = 'REQUEST_DATA'
+export const RECEIVE_DATA = 'RECEIVE_DATA'
+
+export const requestData = component => {
+  return {
+    type: REQUEST_DATA,
+    component
+  }
+}
+
+export const receiveData = (component, data) => {
+  return {
+    type: RECEIVE_DATA,
+    component,
+    data
+  }
+}
+
+const fetchData = (component, type) => {
+  return dispatch => {
+    dispatch(requestData(component))
+    return fetch(`https://raw.githubusercontent.com/FreeCodeCamp/ProjectReferenceData/master/${type}.json`)
+      .then(res => res.json())
+      .then(data => {
+        dispatch(receiveData(component, data))
+      })
+      .catch(err => console.log(err))
+  }
+}
+
+const shouldFetchData = (state, component) => {
+  if (!state[component]) return true
+  if (!state[component].data) return true
+  if (state[component].fetching) return false
+
+  return true
+}
+
+export const fetchDataIfNeeded = (component, type) => {
+  return (dispatch, getState) => {
+    if (shouldFetchData(getState(), component)) {
+      return dispatch(fetchData(component, type))
+    }
+  }
+}

--- a/src/common/store/reducers/index.js
+++ b/src/common/store/reducers/index.js
@@ -1,0 +1,30 @@
+import { combineReducers } from 'redux'
+import { REQUEST_DATA, RECEIVE_DATA } from '../actions'
+
+const store = (state = {}, action) => {
+  switch (action.type) {
+    case REQUEST_DATA:
+      return {
+        ...state,
+        isFetching: true,
+        [action.component]: {
+          ...state[action.component],
+        }
+      }
+    case RECEIVE_DATA:
+      return {
+        ...state,
+        isFetching: false,
+        [action.component]: {
+          ...state[action.component],
+          data: action.data
+        }
+      }
+    default:
+      return state
+  }
+}
+
+export default combineReducers({
+  store
+})

--- a/src/common/store/selectors/index.js
+++ b/src/common/store/selectors/index.js
@@ -1,0 +1,10 @@
+import { createSelector } from 'reselect'
+import R from 'ramda'
+
+const barChartData = state => state.store['bar-chart']
+export const getBarChartData = createSelector(
+  [ barChartData ],
+  data => {
+    return R.values(data)
+  }
+)

--- a/src/index.js
+++ b/src/index.js
@@ -1,0 +1,19 @@
+import React from 'react'
+import { render } from 'react-dom'
+import { browserHistory } from 'react-router'
+import { createStore, applyMiddleware } from 'redux'
+import thunk from 'redux-thunk'
+
+import reducers from '~/store/reducers'
+import Root from '~/containers/Root'
+
+const middleware = [ thunk ]
+
+const store = createStore(
+  reducers,
+  applyMiddleware(...middleware)
+)
+
+render(<Root store={store} history={browserHistory} />,
+  document.querySelector('#root')
+)

--- a/src/main.js
+++ b/src/main.js
@@ -10,7 +10,7 @@ require('isomorphic-fetch');
 
 class App extends Component {
   render() {
-    return(
+    return (
       <BarChart />
     )
   }
@@ -18,7 +18,7 @@ class App extends Component {
 
 class BarChart extends Component {
 
-  constructor () {
+  constructor() {
     super()
     this.state = {
       urls: {
@@ -38,7 +38,7 @@ class BarChart extends Component {
     }
   }
 
-  handleResize () {
+  handleResize() {
     this.setState( Object.assign({}, this.state, {
       window: {
         width: window.innerWidth,
@@ -47,7 +47,7 @@ class BarChart extends Component {
     }))
   }
 
-  handleHover (d) {
+  handleHover(d) {
     const formatDate = d3.timeFormat('%Y - %B')
     const formatCurrency = d3.format('$,.2f')
     const theToolTip = document.getElementById('tool-tip')
@@ -57,7 +57,7 @@ class BarChart extends Component {
     theToolTip.style.top = (d3.event.pageY - 44) + 'px'
   }
 
-  componentDidMount () {
+  componentDidMount() {
     window.addEventListener('resize', this.handleResize.bind(this))
     fetch(this.state.urls.barChart)
       .then(res => res.json())
@@ -69,11 +69,11 @@ class BarChart extends Component {
       )
   }
 
-  componentWillUnmount () {
+  componentWillUnmount() {
     window.removeEventListener('resize', this.handleResize.bind(this))
   }
 
-  render () {
+  render() {
 
       // Set dimensions and margins of the page elements based on viewport dimensions
       const margin = {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -3,7 +3,7 @@ var HtmlWebpackPlugin = require('html-webpack-plugin');
 
 module.exports = {
   devtool: 'eval-source-map',
-  entry: __dirname + '/src/main.js',
+  entry: __dirname + '/src/index.js',
   output: {
     path: __dirname + '/dist',
     filename: '[name]-[hash].js'


### PR DESCRIPTION
Added redux and react router to project. Instead of the component
getting data from state it will now get it from props. This is just the
first implementation so it's just very bare bones right now. I took from
two projects to put this together:
https://github.com/reactjs/redux/tree/master/examples/real-world
https://github.com/reactjs/redux/tree/master/examples/async

Added babel-root-import so that I didn't have to remember how many
levels up a component was. Check this repo for more info:
https://github.com/michaelzoidl/babel-root-import

Added Ramda library to help us transform data because it's functional.
Yeah, FP baby! Check it out here:
http://ramdajs.com/0.22.1/#

Added selectors so that data is memoized. Check up on selectors here:
https://github.com/reactjs/reselect

This was all done in preparation for the app to be
progressive/offline-first. Yay!