### PR TITLE
Update defaultProps for BarChart component

### DIFF
--- a/src/common/containers/BarChart.js
+++ b/src/common/containers/BarChart.js
@@ -1,5 +1,6 @@
-import React, { Component } from 'react'
+import React, { Component, PropTypes } from 'react'
 import { connect } from 'react-redux'
+import R from 'ramda'
 
 import { fetchDataIfNeeded } from '~/store/actions'
 import * as selectors from '~/store/selectors'
@@ -17,6 +18,10 @@ const mapDispatchToProps = dispatch => ({
 @connect(mapStateToProps, mapDispatchToProps)
 export default class BarChart extends Component {
 
+  static propTypes = {
+    data: PropTypes.object
+  }
+
   static defaultProps = {
     data: {}
   }
@@ -28,6 +33,12 @@ export default class BarChart extends Component {
 
   render() {
     const { data } = this.props
-    return <div>Bar Chart Component</div>
+    const barChartData = R.merge(data, data.data)
+    const { source_name } = barChartData
+    return (
+      <div>
+        {source_name}
+      </div>
+    )
   }
 }

--- a/src/common/store/selectors/index.js
+++ b/src/common/store/selectors/index.js
@@ -5,6 +5,6 @@ const barChartData = state => state.store['bar-chart']
 export const getBarChartData = createSelector(
   [ barChartData ],
   data => {
-    return R.values(data)
+    return data
   }
 )

--- a/src/index.js
+++ b/src/index.js
@@ -14,6 +14,7 @@ const store = createStore(
   applyMiddleware(...middleware)
 )
 
-render(<Root store={store} history={browserHistory} />,
+render(
+  <Root store={store} history={browserHistory} />,
   document.querySelector('#root')
 )


### PR DESCRIPTION
Soooooooooo...in React there is the idea of propTypes and defaultProps.
The defaultProps are kind of a placeholder for when the props are
undefined, to handle undefined errors. This allows the component to
wait, and not throw and error, until the props exist and populate the component.
It's more or less a safeguard for this. I did not have an issue with
this initially because I did not check using any more values than the
initial object itself in the component. When I then needed to populate
the component with other values then the errors appeared. I would get value is
undefined, for example. Therefore I looked for how to solve this.
Soooooooooo... to make this a bit easier to use and manage, I changed
the data's defaultProp to be an object and used the Ramda.merge function to
merge the data together, considering that the object we are using is
nested with two objects that both point to a prop named data. So when it
merges it makes just one object with a data field. Because Ramda
function are all curried, when the initial data value does not
exist, that's okay, because the function then will not execute. When the
value, is available, it will execute, and therefore will not throw an
error on the initial render. This now helps us to render the BarChart
component without any errors. Yay!