### PR TITLE
Add container for HeatMap chart

### DIFF
--- a/src/common/components/App.js
+++ b/src/common/components/App.js
@@ -10,6 +10,7 @@ export default function App({ children }) {
         <li><Link to='/'>Home</Link></li>
         <li><Link to='/bar-chart'>Bar Chart</Link></li>
         <li><Link to='/scatter-plot'>Scatter Plot</Link></li>
+        <li><Link to='/heat-map'>Heat Map</Link></li>
       </ul>
       {children || <Home />}
     </div>

--- a/src/common/components/HeatMap.js
+++ b/src/common/components/HeatMap.js
@@ -1,0 +1,7 @@
+import React from 'react'
+
+export default function HeatMap({ data }) {
+  return (
+    <div>{JSON.stringify(data)}</div>
+  )
+}

--- a/src/common/containers/HeatMap.js
+++ b/src/common/containers/HeatMap.js
@@ -1,0 +1,19 @@
+import React from 'react'
+import { mapProps, componentFromProp, compose } from 'recompose'
+import R from 'ramda'
+
+import { windowDimensions, connectComponent, getData, spinnerWhileLoading } from '~/hocs'
+import HeatMap from '~/components/HeatMap'
+
+const enhance = compose(
+  windowDimensions,
+  connectComponent,
+  getData,
+  mapProps(({ data, ...props}) => ({ ...data, ...props})),
+  spinnerWhileLoading(({ data }) => !R.isEmpty(data)),
+)
+const Component = componentFromProp('chart')
+
+export default enhance(props =>
+  <Component chart={HeatMap} {...props} />
+)

--- a/src/common/routes.js
+++ b/src/common/routes.js
@@ -6,12 +6,14 @@ import Home from './components/Home'
 import NoMatch from './components/NoMatch'
 import BarChart from './containers/BarChart'
 import ScatterPlot from './containers/ScatterPlot'
+import HeatMap from './containers/HeatMap'
 
 export default (
   <Route path="/" component={App}>
     <IndexRoute component={Home}/>
     <Route path="bar-chart" component={BarChart} />
     <Route path="scatter-plot" component={ScatterPlot} />
+    <Route path=':slug' component={HeatMap} />
     <Route path="*" component={NoMatch}/>
   </Route>
 )


### PR DESCRIPTION
Added a container for the Heat Map chart. This combines all of what I
have done previously and builds off of it somewhat. Two things to keep
in mind, (1) I am using pattern matching from react-router, and (2) I
will only be using pattern matching for this component and not any
future or previous components. It is a bit of a hack that I will change
for the next component container I create but by no means is this best
practice. Pattern matching works best for templating, which we are not
doing. It did this more so as an experiment to see if I could render
Components dynamically, which I don't believe we can do at the moment.
Secondly, I did this just to play around with pattern matching and have
it as part of our project. It's just me experimenting and by no means is
it something that I think would benefit a production level app. Again,
just experimentation and fun, nothing else. I just wanted to see how far
I could take React and recompose.